### PR TITLE
fix: Allow bot-field info to be sent

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -44,7 +44,7 @@ export default class Contact extends React.Component {
         >
           <p hidden>
             <label>
-              Don’t fill this out: <input name="bot-field" />
+              Don’t fill this out: <input name="bot-field" onChange={this.handleChange} />
             </label>
           </p>
           <p>


### PR DESCRIPTION
Without an onChange handler for the honeypot input, the value a bot would insert would never get sent.